### PR TITLE
Remove the block around the canonical tag

### DIFF
--- a/core-bundle/src/Resources/contao/templates/frontend/fe_page.html5
+++ b/core-bundle/src/Resources/contao/templates/frontend/fe_page.html5
@@ -13,11 +13,9 @@
       <meta name="generator" content="Contao Open Source CMS">
     <?php $this->endblock(); ?>
 
-    <?php $this->block('canonical'); ?>
-      <?php if ($this->canonical): ?>
-        <link rel="canonical" href="<?= $this->canonical; ?>">
-      <?php endif; ?>
-    <?php $this->endblock(); ?>
+    <?php if ($this->canonical): ?>
+      <link rel="canonical" href="<?= $this->canonical ?>">
+    <?php endif; ?>
 
     <?= $this->viewport ?>
     <?= $this->framework ?>


### PR DESCRIPTION
Why? Because we do not need a block to use a custom canonical URL:

```php
<?php $this->extend('fe_page'); ?>
<?php

$this->canonical = $this->getCustomCanonicalUrl();
```

And I highly doubt that someone wants to replace `<link rel="canonical" href="<?= $this->canonical ?>">` with something entirely different, because there is no other way to define the canonical URL in an HTML document.