### PR TITLE
Disable HSTS if root page is configured on http

### DIFF
--- a/core-bundle/config/controller.yaml
+++ b/core-bundle/config/controller.yaml
@@ -182,6 +182,11 @@ services:
         tags:
             - controller.service_arguments
 
+    Contao\CoreBundle\Controller\RedirectController:
+        public: true
+        arguments:
+            - '@Symfony\Bundle\FrameworkBundle\Controller\RedirectController'
+
     Contao\CoreBundle\Controller\RobotsTxtController:
         arguments:
             - '@contao.routing.page_finder'

--- a/core-bundle/src/Controller/RedirectController.php
+++ b/core-bundle/src/Controller/RedirectController.php
@@ -20,22 +20,21 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
-class RedirectController extends SymfonyRedirectController
+class RedirectController
 {
+    public function __construct(private readonly SymfonyRedirectController $controller)
+    {
+    }
+
     public function urlRedirectAction(Request $request, string $path, bool $permanent = false, string $scheme = null, int $httpPort = null, int $httpsPort = null, bool $keepRequestMethod = false): Response
     {
-        $response = parent::urlRedirectAction($request, $path, $permanent, $scheme, $httpPort, $httpsPort, $keepRequestMethod);
+        $response = $this->controller->urlRedirectAction($request, $path, $permanent, $scheme, $httpPort, $httpsPort, $keepRequestMethod);
         $pageModel = $request->attributes->get('pageModel');
 
-        if (
-            $pageModel instanceof PageModel
-            && !$pageModel->useSSL
-            && $request->isSecure()
-        ) {
+        if ($pageModel instanceof PageModel && !$pageModel->useSSL && $request->isSecure()) {
             $response->headers->set('Strict-Transport-Security', 'max-age=0');
         }
 
         return $response;
     }
-
 }

--- a/core-bundle/src/Controller/RedirectController.php
+++ b/core-bundle/src/Controller/RedirectController.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Controller;
+
+use Contao\PageModel;
+use Symfony\Bundle\FrameworkBundle\Controller\RedirectController as SymfonyRedirectController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @internal
+ */
+class RedirectController extends SymfonyRedirectController
+{
+    public function urlRedirectAction(Request $request, string $path, bool $permanent = false, string $scheme = null, int $httpPort = null, int $httpsPort = null, bool $keepRequestMethod = false): Response
+    {
+        $response = parent::urlRedirectAction($request, $path, $permanent, $scheme, $httpPort, $httpsPort, $keepRequestMethod);
+        $pageModel = $request->attributes->get('pageModel');
+
+        if (
+            $pageModel instanceof PageModel
+            && !$pageModel->useSSL
+            && $request->isSecure()
+        ) {
+            $response->headers->set('Strict-Transport-Security', 'max-age=0');
+        }
+
+        return $response;
+    }
+
+}

--- a/core-bundle/src/Routing/Matcher/UrlMatcher.php
+++ b/core-bundle/src/Routing/Matcher/UrlMatcher.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Routing\Matcher;
 
+use Contao\CoreBundle\Controller\RedirectController;
 use Symfony\Cmf\Component\Routing\NestedMatcher\FinalMatcherInterface;
 use Symfony\Cmf\Component\Routing\RouteObjectInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -46,7 +47,7 @@ class UrlMatcher extends RedirectableUrlMatcher implements FinalMatcherInterface
     public function redirect($path, $route, $scheme = null): array
     {
         return [
-            '_controller' => 'Symfony\\Bundle\\FrameworkBundle\\Controller\\RedirectController::urlRedirectAction',
+            '_controller' => RedirectController::class.'::urlRedirectAction',
             'path' => $path,
             'permanent' => true,
             'scheme' => $scheme,

--- a/core-bundle/tests/Controller/RedirectControllerTest.php
+++ b/core-bundle/tests/Controller/RedirectControllerTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Controller;
+
+use Contao\CoreBundle\Controller\RedirectController;
+use Contao\CoreBundle\Tests\TestCase;
+use Contao\PageModel;
+use Symfony\Bundle\FrameworkBundle\Controller\RedirectController as SymfonyRedirectController;
+use Symfony\Component\HttpFoundation\HeaderBag;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+class RedirectControllerTest extends TestCase
+{
+    public function testAddsTheHeader(): void
+    {
+        $response = $this->createMock(RedirectResponse::class);
+        $response->headers = $this->createMock(HeaderBag::class);
+        $response->headers
+            ->expects($this->once())
+            ->method('set')
+            ->with('Strict-Transport-Security', 'max-age=0')
+        ;
+
+        $inner = $this->createMock(SymfonyRedirectController::class);
+        $inner
+            ->expects($this->once())
+            ->method('urlRedirectAction')
+            ->willReturn($response)
+        ;
+
+        $pageModel = $this->mockClassWithProperties(PageModel::class, ['useSSL' => false]);
+        $request = Request::create('https://localhost/');
+        $request->attributes->set('pageModel', $pageModel);
+
+        $controller = new RedirectController($inner);
+        $controller->urlRedirectAction($request, '/foo/bar');
+    }
+
+    public function testDoesNotAddTheHeaderForInsecureRequess(): void
+    {
+        $response = $this->createMock(RedirectResponse::class);
+        $response->headers = $this->createMock(HeaderBag::class);
+        $response->headers
+            ->expects($this->never())
+            ->method('set')
+        ;
+
+        $inner = $this->createMock(SymfonyRedirectController::class);
+        $inner
+            ->expects($this->once())
+            ->method('urlRedirectAction')
+            ->willReturn($response)
+        ;
+
+        $pageModel = $this->mockClassWithProperties(PageModel::class, ['useSSL' => false]);
+        $request = Request::create('http://localhost/');
+        $request->attributes->set('pageModel', $pageModel);
+
+        $controller = new RedirectController($inner);
+        $controller->urlRedirectAction($request, '/foo/bar');
+    }
+
+    public function testDoesNotAddTheHeaderWithoutPageModel(): void
+    {
+        $response = $this->createMock(RedirectResponse::class);
+        $response->headers = $this->createMock(HeaderBag::class);
+        $response->headers
+            ->expects($this->never())
+            ->method('set')
+        ;
+
+        $inner = $this->createMock(SymfonyRedirectController::class);
+        $inner
+            ->expects($this->once())
+            ->method('urlRedirectAction')
+            ->willReturn($response)
+        ;
+
+        $request = Request::create('https://localhost/');
+
+        $controller = new RedirectController($inner);
+        $controller->urlRedirectAction($request, '/foo/bar');
+    }
+
+    public function testDoesNotAddTheHeaderIfRootPageUsesSSL(): void
+    {
+        $response = $this->createMock(RedirectResponse::class);
+        $response->headers = $this->createMock(HeaderBag::class);
+        $response->headers
+            ->expects($this->never())
+            ->method('set')
+        ;
+
+        $inner = $this->createMock(SymfonyRedirectController::class);
+        $inner
+            ->expects($this->once())
+            ->method('urlRedirectAction')
+            ->willReturn($response)
+        ;
+
+        $pageModel = $this->mockClassWithProperties(PageModel::class, ['useSSL' => true]);
+        $request = Request::create('https://localhost/');
+        $request->attributes->set('pageModel', $pageModel);
+
+        $controller = new RedirectController($inner);
+        $controller->urlRedirectAction($request, '/foo/bar');
+    }
+}


### PR DESCRIPTION
I tested this locally and it seems to work as expected. The http:// redirect generated from the root page setting disables HSTS.

<img width="233" alt="Bildschirmfoto 2023-11-23 um 11 09 49" src="https://github.com/Toflar/contao/assets/1073273/83cc888b-b82d-4851-a033-462a17f7d6df">
